### PR TITLE
Prevent duplicate calls to symbols API.

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,9 +2,5 @@
 
 # ToDo List
 
-* Support setting API Key from environment variable
-* Add ability to download audio files (require Node.js? or not)
-* Build a sample app that uses the library
-* Pass NPM Package version to the API
-* Make exchange/symbol required fields.
-* Cache symbols in memory
+* Add ability to stream audio bytes rather than download to file.
+* Build a sample app that uses the library.

--- a/src/lib/company.spec.ts
+++ b/src/lib/company.spec.ts
@@ -165,17 +165,21 @@ const level4Response = {
 const sp500CompaniesTxtFile = 'ABC\nDEF';
 
 beforeAll(() => {
-  global.fetch = jest.fn((url: string) => {
-    if (url === 'https://v2.api.earningscall.biz/symbols-v2.txt?apikey=demo') {
+  global.fetch = jest.fn((url: URL) => {
+    if (
+      url.toString() ===
+      'https://v2.api.earningscall.biz/symbols-v2.txt?apikey=demo'
+    ) {
       return Promise.resolve({
         ok: true,
         status: 200,
         text: () => Promise.resolve(symbolsResponseText),
+        headers: new Headers({}),
       });
     }
 
     if (
-      url ===
+      url.toString() ===
       'https://v2.api.earningscall.biz/events?apikey=demo&exchange=NASDAQ&symbol=ABC'
     ) {
       return Promise.resolve({
@@ -186,138 +190,134 @@ beforeAll(() => {
     }
 
     if (
-      url ===
+      url.toString() ===
       'https://v2.api.earningscall.biz/symbols-v2.txt?apikey=My+Custom+API+Key'
     ) {
       return Promise.resolve({
         ok: true,
         status: 200,
         text: () => Promise.resolve(symbolsResponseText),
+        headers: new Headers({}),
       });
     }
 
     if (
-      url ===
+      url.toString() ===
       'https://v2.api.earningscall.biz/transcript?apikey=My+Custom+API+Key&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=1'
     ) {
       return Promise.resolve({
         ok: true,
         status: 200,
         json: () => transcriptResponseJson,
+        headers: new Headers({}),
       });
     }
 
     if (
-      url ===
+      url.toString() ===
       'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=1'
     ) {
       return Promise.resolve({
         ok: true,
         status: 200,
         json: () => transcriptResponseJson,
+        headers: new Headers({}),
       });
     }
     if (
-      url ===
+      url.toString() ===
       'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=2'
     ) {
       return Promise.resolve({
         ok: true,
         status: 200,
         json: () => transcriptLevel2ResponseJson,
+        headers: new Headers({}),
       });
     }
     if (
-      url ===
+      url.toString() ===
       'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=3'
     ) {
       return Promise.resolve({
         ok: true,
         status: 200,
         json: () => transcriptLevel3ResponseJson,
+        headers: new Headers({}),
       });
     }
     if (
-      url ===
+      url.toString() ===
       'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=4'
     ) {
       return Promise.resolve({
         ok: true,
         status: 200,
         json: () => level4Response,
+        headers: new Headers({}),
       });
     }
 
     if (
-      url === 'https://v2.api.earningscall.biz/symbols/sp500.txt?apikey=demo'
+      url.toString() ===
+      'https://v2.api.earningscall.biz/symbols/sp500.txt?apikey=demo'
     ) {
       return Promise.resolve({
         ok: true,
         status: 200,
         text: () => Promise.resolve(sp500CompaniesTxtFile),
+        headers: new Headers({}),
       });
     }
 
     if (
-      url ===
+      url.toString() ===
       'https://v2.api.earningscall.biz/transcript?apikey=CUSTOM_API_KEY&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=1'
     ) {
       return Promise.resolve({
         ok: false,
         status: 404,
+        headers: new Headers({}),
       });
     }
 
     if (
-      url ===
+      url.toString() ===
       'https://v2.api.earningscall.biz/transcript?apikey=BASIC_PLAN_API_KEY&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=4'
     ) {
       return Promise.resolve({
         ok: false,
         status: 403,
-        headers: {
-          get: (key: string) => {
-            if (key.toLowerCase() === 'x-plan-name') {
-              return 'basic';
-            }
-            return undefined;
-          },
-        },
+        headers: new Headers({
+          'x-plan-name': 'basic',
+        }),
       });
     }
 
     if (
-      url ===
+      url.toString() ===
       'https://v2.api.earningscall.biz/symbols-v2.txt?apikey=INVALID_API_KEY'
     ) {
       return Promise.resolve({
         ok: false,
         status: 401,
+        headers: new Headers({}),
       });
     }
 
     if (
-      url ===
+      url.toString() ===
       'https://v2.api.earningscall.biz/audio?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1'
     ) {
       return Promise.resolve({
         ok: true,
         status: 200,
         arrayBuffer: () => Promise.resolve(new Uint8Array([0, 0, 0, 0, 0])),
-        headers: {
-          get: (key: string) => {
-            switch (key.toLowerCase()) {
-              case 'content-length':
-                return '100';
-              case 'content-type':
-                return 'audio/mpeg';
-              case 'last-modified':
-                return '2024-01-01T00:00:00.000Z';
-              default:
-                return null;
-            }
-          },
-        },
+        headers: new Headers({
+          'content-length': '100',
+          'content-type': 'audio/mpeg',
+          'last-modified': '2024-01-01T00:00:00.000Z',
+        }),
       });
     }
 

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,6 +1,6 @@
 export class ClientError extends Error {
   readonly response: Response;
-  constructor(message = 'Client error', response: Response) {
+  constructor(message: string, response: Response) {
     super(message);
     this.name = 'ClientError';
     this.response = response;
@@ -11,24 +11,24 @@ export class ClientError extends Error {
 }
 
 export class UnauthorizedError extends ClientError {
-  constructor(message = 'Unauthorized', response: Response) {
-    super(message, response);
+  constructor(response: Response) {
+    super('Unauthorized', response);
     this.name = 'UnauthorizedError';
     Object.setPrototypeOf(this, UnauthorizedError.prototype);
   }
 }
 
 export class BadRequestError extends ClientError {
-  constructor(message = 'Bad request', response: Response) {
-    super(message, response);
+  constructor(response: Response) {
+    super('Bad request', response);
     this.name = 'BadRequestError';
     Object.setPrototypeOf(this, BadRequestError.prototype);
   }
 }
 
 export class NotFoundError extends ClientError {
-  constructor(message = 'Not found', response: Response) {
-    super(message, response);
+  constructor(response: Response) {
+    super('Not found', response);
     this.name = 'NotFoundError';
 
     // This line is needed to maintain proper prototype chain in TypeScript
@@ -37,15 +37,15 @@ export class NotFoundError extends ClientError {
 }
 
 export class TooManyRequestsError extends ClientError {
-  constructor(message = 'Too many requests', response: Response) {
-    super(message, response);
+  constructor(response: Response) {
+    super('Too many requests', response);
     this.name = 'TooManyRequestsError';
     Object.setPrototypeOf(this, TooManyRequestsError.prototype);
   }
 }
 
 export class InsufficientApiAccessError extends ClientError {
-  constructor(message = 'Insufficient API access rights', response: Response) {
+  constructor(message: string, response: Response) {
     super(message, response);
     this.name = 'InsufficientApiAccessError';
 
@@ -55,7 +55,7 @@ export class InsufficientApiAccessError extends ClientError {
 }
 
 export class MissingApiKeyError extends Error {
-  constructor(message = 'Missing API key') {
+  constructor(message: string) {
     super(message);
     this.name = 'MissingApiKeyError';
 
@@ -64,15 +64,14 @@ export class MissingApiKeyError extends Error {
 }
 
 export class InternalServerError extends ClientError {
-  constructor(message = 'Internal server error', response: Response) {
-    super(message, response);
+  constructor(response: Response) {
+    super('Internal server error', response);
     this.name = 'InternalServerError';
     Object.setPrototypeOf(this, InternalServerError.prototype);
   }
 }
-
 export class UnexpectedError extends ClientError {
-  constructor(message = 'Unexpected error', response: Response) {
+  constructor(message: string, response: Response) {
     super(message, response);
     this.name = 'UnexpectedError';
     Object.setPrototypeOf(this, UnexpectedError.prototype);

--- a/src/lib/symbols.spec.ts
+++ b/src/lib/symbols.spec.ts
@@ -1,4 +1,43 @@
-import { indexToExchange } from './symbols';
+import {
+  clearSymbols,
+  getSymbols,
+  indexToExchange,
+  loadSymbols,
+} from './symbols';
+
+const symbolsResponseText =
+  '1\tABC\tABC Test Company Inc.\t9\t30\n1\tDEF\tDEF Test Company Inc.\t9\t122';
+
+beforeAll(() => {
+  global.fetch = jest.fn((url: URL) => {
+    if (
+      url.toString() ===
+      'https://v2.api.earningscall.biz/symbols-v2.txt?apikey=demo'
+    ) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: () => Promise.resolve(symbolsResponseText),
+        headers: new Headers({
+          'Content-Length': '100',
+          'Content-Type': 'application/json',
+          'Last-Modified': '2024-01-01T00:00:00.000Z',
+          'Cache-Control': 'max-age=3600, expires=2024-01-01T01:00:00.000Z',
+        }),
+      });
+    }
+
+    return Promise.reject(new Error(`Unhandled request: ${url}`));
+  }) as jest.Mock;
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+beforeEach(() => {
+  clearSymbols();
+});
 
 describe('symbols', () => {
   it('should convert index to exchange', () => {
@@ -8,5 +47,109 @@ describe('symbols', () => {
   it('should fail to convert invalid index', () => {
     expect(indexToExchange(-1)).toBe('UNKNOWN');
     expect(indexToExchange(99999)).toBe('UNKNOWN');
+  });
+
+  it('should load symbols', async () => {
+    const symbols = await loadSymbols();
+    expect(symbols.get('NASDAQ', 'ABC')).toBeDefined();
+    expect(symbols.get('NASDAQ', 'DEF')).toBeDefined();
+  });
+
+  it('should work without response headers', async () => {
+    global.fetch = jest.fn((url: URL) => {
+      if (
+        url.toString() ===
+        'https://v2.api.earningscall.biz/symbols-v2.txt?apikey=demo'
+      ) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(symbolsResponseText),
+          headers: new Headers({}),
+        });
+      }
+
+      return Promise.reject(new Error(`Unhandled request: ${url}`));
+    }) as jest.Mock;
+
+    const symbols = await loadSymbols();
+    expect(symbols.get('NASDAQ', 'ABC')).toBeDefined();
+    expect(symbols.get('NASDAQ', 'DEF')).toBeDefined();
+  });
+
+  it('should cache symbols until expiration date then reload them', async () => {
+    var numberOfSymbolsCalls = 0;
+    global.fetch = jest.fn((url: URL) => {
+      if (
+        url.toString() ===
+        'https://v2.api.earningscall.biz/symbols-v2.txt?apikey=demo'
+      ) {
+        numberOfSymbolsCalls++;
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(symbolsResponseText),
+          headers: new Headers({
+            // Cause the symbols to expire in 1 second
+            'Cache-Control': 'max-age=1',
+          }),
+        });
+      }
+
+      return Promise.reject(new Error(`Unhandled request: ${url}`));
+    }) as jest.Mock;
+
+    const symbols = await getSymbols();
+    expect(symbols.get('NASDAQ', 'ABC')).toBeDefined();
+    expect(symbols.get('NASDAQ', 'DEF')).toBeDefined();
+    expect(numberOfSymbolsCalls).toBe(1);
+    const symbols2 = await getSymbols();
+    expect(symbols2.get('NASDAQ', 'ABC')).toBeDefined();
+    expect(symbols2.get('NASDAQ', 'DEF')).toBeDefined();
+    expect(numberOfSymbolsCalls).toBe(1);
+    // Sleep for 2 seconds
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    const symbols3 = await getSymbols();
+    expect(numberOfSymbolsCalls).toBe(2);
+    expect(symbols3.get('NASDAQ', 'ABC')).toBeDefined();
+    expect(symbols3.get('NASDAQ', 'DEF')).toBeDefined();
+  });
+
+  it('should handle http throttle error', async () => {
+    var numberOfSymbolsCalls = 0;
+    global.fetch = jest.fn((url: URL) => {
+      if (
+        url.toString() ===
+        'https://v2.api.earningscall.biz/symbols-v2.txt?apikey=demo'
+      ) {
+        numberOfSymbolsCalls++;
+        return Promise.resolve({
+          ok: false,
+          status: 429,
+        });
+      }
+      return Promise.reject(new Error(`Unhandled request: ${url}`));
+    }) as jest.Mock;
+
+    expect(getSymbols()).rejects.toThrow('Too many requests');
+  });
+
+  it('should handle http internal server error', async () => {
+    var numberOfSymbolsCalls = 0;
+    global.fetch = jest.fn((url: URL) => {
+      if (
+        url.toString() ===
+        'https://v2.api.earningscall.biz/symbols-v2.txt?apikey=demo'
+      ) {
+        numberOfSymbolsCalls++;
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+        });
+      }
+      return Promise.reject(new Error(`Unhandled request: ${url}`));
+    }) as jest.Mock;
+
+    expect(getSymbols()).rejects.toThrow('Internal server error');
   });
 });


### PR DESCRIPTION
Cache the Symbols response for 1 day, or respect the max-age cache-control header from the server.  In that case, don't re-load symbols, just use the symbols already in memory.