### PR TITLE
Improve type definitions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## [1.1.0](https://github.com/EarningsCall/earningscall-js/compare/v1.0.4...v1.1.0) (2024-12-16)
 
--   BREAKING CHANGE: Remove `getTranscript()` function from `Company` class.  In it's place, there are now 4 new functions: `getBasicTranscript()`, `getSpeakerGroups()`, `getWordLevelTimestamps()`, and `getQuestionAndAnswerTranscript()`.
+-   BREAKING CHANGE: Remove `getTranscript()` function from `Company` class.  In it's place, there are now 4 new functions: `getBasicTranscript()`, `getSpeakerGroups()`, `getWordLevelTimestamps()`, and `getQuestionAndAnswerTranscript()`.  This is to enhance the developer experience by providing Types that are specific to type of transcript data that is being retrieved.
 -   BREAKING CHANGE: Change function name from `getAudioFile()` to `downloadAudioFile()`.
 -   Add `getBasicTranscript` method to `Company` class.
 -   Add `getSpeakerGroups` method to `Company` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.1.0](https://github.com/EarningsCall/earningscall-js/compare/v1.0.4...v1.1.0) (2024-12-16)
+
+-   BREAKING CHANGE: Remove `getTranscript()` function from `Company` class.  In it's place, there are now 4 new functions: `getBasicTranscript()`, `getSpeakerGroups()`, `getWordLevelTimestamps()`, and `getQuestionAndAnswerTranscript()`.
+-   BREAKING CHANGE: Change function name from `getAudioFile()` to `downloadAudioFile()`.
+-   Add `getBasicTranscript` method to `Company` class.
+-   Add `getSpeakerGroups` method to `Company` class.
+-   Add `getWordLevelTimestamps` method to `Company` class.
+-   Add `getQuestionAndAnswerTranscript` method to `Company` class.
+
+
 ## [1.0.4](https://github.com/EarningsCall/earningscall-js/compare/v1.0.3...v1.0.4) (2024-12-15)
 
 -   Add various documentation comments to the code.

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ const { getCompany } = require('earningscall');
 
 ## Examples
 
-### Get Transcript for a Single Year and Quarter
+### Get Basic Transcript for a Single Year and Quarter
 
-If you want to retrieve a specific transcript of a company for a single year and quarter, you can do so with the `getTranscript` method.
+If you want to retrieve a specific transcript of a company for a single year and quarter, you can do so with the `getBasicTranscript` method.
 
 
 ```typescript
@@ -58,7 +58,7 @@ const company = await getCompany({ symbol: "AAPL" });  // Get Company object by 
 const companyInfo = company.companyInfo;
 console.log(`Company name: ${companyInfo.name} Sector: ${companyInfo.sector} Industry: ${companyInfo.industry}`);
 
-const transcript = await company.getTranscript({ year: 2021, quarter: 3 });
+const transcript = await company.getBasicTranscript({ year: 2021, quarter: 3 });
 console.log(`${companyInfo.symbol} Q3 2021 Transcript: "${transcript?.text.slice(0, 100)}..."`);
 ```
 
@@ -81,7 +81,7 @@ const company = await getCompany({ symbol: "AAPL" });
 console.log(`Getting all transcripts for: ${company.companyInfo.name}...`);
 const events = await company.events();
 for (const event of events) {
-  const transcript = await company.getTranscript({ event });
+  const transcript = await company.getBasicTranscript({ event });
   console.log(`${company.companyInfo.symbol} Q${event.quarter} ${event.year}`);
   console.log(` * Transcript Text: "${transcript?.text.slice(0, 100)}..."`);
 }
@@ -110,10 +110,10 @@ import { getCompany } from "earningscall";
 
 const company = await getCompany({ symbol: "AAPL" });
 
-const transcriptLevel2 = await company.getTranscript({ year: 2024, quarter: 2, level: 2 });
-const firstSpeaker = transcriptLevel2!.speakers![0];
-console.log(`Speaker: ${firstSpeaker?.speakerInfo?.name}, ${firstSpeaker?.speakerInfo?.title}`);
-console.log(`Text: ${firstSpeaker?.text}`);
+const speakerGroups = await company.getSpeakerGroups({ year: 2024, quarter: 2 });
+const firstSpeaker = speakerGroups!.speakers[0];
+console.log(`Speaker: ${firstSpeaker.speakerInfo?.name}, ${firstSpeaker.speakerInfo?.title}`);
+console.log(`Text: ${firstSpeaker.text}`);
 ```
 
 Output
@@ -131,12 +131,8 @@ import { getCompany } from "earningscall";
 
 const company = await getCompany({ symbol: "AAPL" });
 // Level 3 Transcript Data includes words and start times
-const transcriptLevel3 = await company.getTranscript({ year: 2021, quarter: 3, level: 3 });
-const firstSpeaker = transcriptLevel3?.speakers![0];
-if (!firstSpeaker) {
-  console.log("No speakers found in transcript");
-  return;
-}
+const transcript = await company.getWordLevelTimestamps({ year: 2021, quarter: 3 });
+const firstSpeaker = transcript?.speakers[0];
 const wordsAndStartTimes = firstSpeaker?.words?.map((word, index) => ({
   word,
   startTime: firstSpeaker?.startTimes![index]
@@ -166,9 +162,9 @@ import { getCompany } from "earningscall";
 
 const company = await getCompany({ symbol: "AAPL" });
 
-const transcriptLevel4 = await company.getTranscript({ year: 2021, quarter: 3, level: 4 });
-console.log(`${company} Q3 2021 Prepared Remarks: "${transcriptLevel4?.preparedRemarks?.slice(0, 100)}..."`);
-console.log(`${company} Q3 2021 Q&A: "${transcriptLevel4?.questionsAndAnswers?.slice(0, 100)}..."`);
+const transcript = await company.getQuestionAndAnswerTranscript({ year: 2021, quarter: 3 });
+console.log(`${company} Q3 2021 Prepared Remarks: "${transcript?.preparedRemarks.slice(0, 100)}..."`);
+console.log(`${company} Q3 2021 Q&A: "${transcript?.questionsAndAnswers.slice(0, 100)}..."`);
 ```
 
 Output
@@ -186,7 +182,7 @@ import { getCompany } from "earningscall";
 
 const company = await getCompany({ symbol: "AAPL" });
 console.log(`Downloading audio file for ${company} Q3 2021...`);
-const audioFile = await company.getAudioFile({ year: 2021, quarter: 3 });
+const audioFile = await company.downloadAudioFile({ year: 2021, quarter: 3 });
 console.log(`Audio file downloaded to: ${audioFile.outputFilePath}`);
 ```
 

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -1,0 +1,8 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/*.integration.spec.ts'],
+  verbose: true,
+  testTimeout: 30000
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "earningscall",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "The EarningsCall JavaScript library provides convenient access to the EarningsCall API.  It includes a pre-defined set of classes for API resources that initialize themselves dynamically from API responses.",
   "author": "EarningsCall <dev@earningscall.biz>",
   "main": "build/main/index.js",
@@ -47,7 +47,8 @@
     "doc:publish": "gh-pages -m \"[ci skip] Updates\" -d build/docs",
     "version": "standard-version",
     "reset-hard": "git clean -dfx && git reset --hard",
-    "prepare-release": "run-s reset-hard test doc:html version doc:publish"
+    "prepare-release": "run-s reset-hard test doc:html version doc:publish",
+    "test:integration": "jest --config=jest.integration.config.js"
   },
   "engines": {
     "node": ">=18"
@@ -108,11 +109,13 @@
     "preset": "ts-jest",
     "testEnvironment": "node",
     "testMatch": [
-      "**/*.spec.ts"
+      "**/*.spec.ts",
+      "!**/*.integration.spec.ts"
     ],
     "collectCoverageFrom": [
       "src/**/*.ts",
-      "!src/**/*.d.ts"
+      "!src/**/*.d.ts",
+      "!src/**/*.integration.spec.ts"
     ],
     "coverageThreshold": {
       "global": {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,7 +9,7 @@ import {
   UnauthorizedError,
   UnexpectedError,
 } from './errors';
-import { GetAudioFileResponse } from '../types';
+import { DownloadAudioFileResponse } from '../types';
 
 const DOMAIN = 'earningscall.biz';
 const API_BASE = `https://v2.api.${DOMAIN}`;
@@ -142,7 +142,7 @@ export async function downloadAudioFile(
   year: number,
   quarter: number,
   outputFilePath?: string,
-): Promise<GetAudioFileResponse> {
+): Promise<DownloadAudioFileResponse> {
   const params = {
     ...apiKeyParam(),
     exchange,
@@ -170,7 +170,7 @@ export async function downloadAudioFile(
   const uint8Array = new Uint8Array(buffer);
   writer.write(uint8Array);
 
-  const result: GetAudioFileResponse = {
+  const result: DownloadAudioFileResponse = {
     outputFilePath: localFilename,
     contentLength,
     contentType: contentType || undefined,

--- a/src/lib/company.integration.spec.ts
+++ b/src/lib/company.integration.spec.ts
@@ -1,0 +1,105 @@
+import { getCompany } from '../index';
+
+describe('integration', () => {
+  test('fetch real company data from demo API', async () => {
+    // Use real API endpoint instead of mocks
+    const company = await getCompany({ symbol: 'AAPL' });
+
+    // Basic company info validation
+    expect(company.name).toContain('Apple');
+    expect(company.companyInfo.exchange).toBe('NASDAQ');
+    expect(company.companyInfo.symbol).toBe('AAPL');
+
+    // Fetch events
+    const events = await company.events();
+    expect(events.length).toBeGreaterThan(0);
+    expect(events[0]).toHaveProperty('year');
+    expect(events[0]).toHaveProperty('quarter');
+    expect(events[0]).toHaveProperty('conferenceDate');
+
+    const transcript = await company.getBasicTranscript({
+      year: 2024,
+      quarter: 1,
+    });
+
+    expect(transcript).toBeDefined();
+    expect(transcript?.event.year).toBe(2024);
+    expect(transcript?.event.quarter).toBe(1);
+    expect(transcript?.text).toBeTruthy();
+    expect(transcript?.text.slice(0, 100)).toBe(
+      "Good day, and welcome to the Apple Q1 Fiscal Year 2024 Earnings Conference Call. Today's call is bei",
+    );
+  }, 10_000); // Increase timeout since we're making real API calls
+
+  test('fetch non-demo company data from demo API', async () => {
+    expect(async () => {
+      await getCompany({ symbol: 'NVDA' });
+    }).rejects.toThrow(
+      '"NVDA" requires an API Key for access. To get your API Key, see: https://earningscall.biz/api-pricing',
+    );
+  });
+
+  test('fetch speaker groups', async () => {
+    const company = await getCompany({ symbol: 'AAPL' });
+    const speakerGroups = await company.getSpeakerGroups({
+      year: 2024,
+      quarter: 1,
+    });
+    expect(speakerGroups).toBeDefined();
+    expect(speakerGroups?.speakers.length).toBe(61);
+    const allSpeakersAndTitles = speakerGroups?.speakers.map(
+      (speaker) =>
+        `${speaker.speakerInfo?.name} (${speaker.speakerInfo?.title})`,
+    );
+    expect(allSpeakersAndTitles?.slice(0, 4)).toEqual([
+      'Operator (Conference Call Host)',
+      'Suhasini Chandramouli (Director of Investor Relations)',
+      'Tim Cook (CEO)',
+      'Luca Maestri (CFO)',
+    ]);
+  });
+
+  test('fetch word level timestamps', async () => {
+    const company = await getCompany({ symbol: 'AAPL' });
+    const transcript = await company.getWordLevelTimestamps({
+      year: 2024,
+      quarter: 1,
+    });
+    expect(transcript).toBeDefined();
+    expect(transcript?.speakers.length).toBeGreaterThan(0);
+    expect(transcript?.speakers[0].words.length).toBeGreaterThan(0);
+    expect(transcript?.speakers[0].startTimes.length).toBeGreaterThan(0);
+    expect(transcript?.speakers[0].words.slice(0, 10)).toEqual([
+      'Good',
+      'day,',
+      'and',
+      'welcome',
+      'to',
+      'the',
+      'Apple',
+      'Q1',
+      'Fiscal',
+      'Year',
+    ]);
+    expect(transcript?.speakers[0].startTimes.slice(0, 10)).toEqual([
+      0.526, 0.726, 1.167, 1.307, 1.748, 1.888, 2.068, 2.469, 3.029, 3.991,
+    ]);
+  });
+
+  test('fetch questions and answers transcript', async () => {
+    const company = await getCompany({ symbol: 'AAPL' });
+    const transcript = await company.getQuestionAndAnswerTranscript({
+      year: 2024,
+      quarter: 1,
+    });
+    expect(transcript).toBeDefined();
+    expect(transcript?.preparedRemarks.length).toBeGreaterThan(0);
+    expect(transcript?.questionsAndAnswers.length).toBeGreaterThan(0);
+    expect(transcript?.preparedRemarks.slice(0, 100)).toBe(
+      "Good day, and welcome to the Apple Q1 Fiscal Year 2024 Earnings Conference Call. Today's call is bei",
+    );
+    expect(transcript?.questionsAndAnswers.slice(0, 100)).toBe(
+      "We'll go ahead and take our first question from Eric Woodring with Morgan Stanley. Please go ahead. ",
+    );
+  });
+});

--- a/src/lib/company.spec.ts
+++ b/src/lib/company.spec.ts
@@ -283,9 +283,9 @@ describe('company', () => {
     ]);
     const company = await getCompany({ symbol: 'ABC' });
     setApiKey('WRONG_API_KEY');
-    await expect(company.getBasicTranscript({ year: 2022, quarter: 1 })).rejects.toThrow(
-      'Unauthorized',
-    );
+    await expect(
+      company.getBasicTranscript({ year: 2022, quarter: 1 }),
+    ).rejects.toThrow('Unauthorized');
   });
 
   test('get transcript is missing', async () => {
@@ -321,9 +321,9 @@ describe('company', () => {
       },
     ]);
     const company = await getCompany({ symbol: 'ABC' });
-    await expect(company.getSpeakerGroups({ year: 2022, quarter: 1 })).rejects.toThrow(
-      'Too many requests',
-    );
+    await expect(
+      company.getSpeakerGroups({ year: 2022, quarter: 1 }),
+    ).rejects.toThrow('Too many requests');
   });
 
   test('get speaker groups not found', async () => {
@@ -611,7 +611,6 @@ describe('company', () => {
     expect(transcript?.speakers[1].speakerInfo?.name).toBe('John Smith');
     expect(transcript?.speakers[1].speakerInfo?.title).toBe('CEO');
   });
-
 
   test('get transcript level 3 http 429 too many requests', async () => {
     setMockApiResponses([

--- a/src/lib/company.spec.ts
+++ b/src/lib/company.spec.ts
@@ -8,11 +8,22 @@ import {
   getAllCompanies,
   getCompany,
   getSP500Companies,
+  GetTranscriptOptions,
   setApiKey,
 } from '../index';
 
 const symbolsResponseText =
   '1\tABC\tABC Test Company Inc.\t9\t30\n1\tDEF\tDEF Test Company Inc.\t9\t122';
+
+const demoSymbolsMock = {
+  url: 'https://v2.api.earningscall.biz/symbols-v2.txt?apikey=demo',
+  result: {
+    ok: true,
+    status: 200,
+    text: () => Promise.resolve(symbolsResponseText),
+    headers: new Headers({}),
+  },
+};
 
 const eventsResponseJson = {
   company_name: 'Apple Inc.',
@@ -166,137 +177,8 @@ const sp500CompaniesTxtFile = 'ABC\nDEF';
 const sp500CompaniesWithNonexistentSymbolsTxtFile =
   'ABC\nDEF\nDOESNOTEXIST\nDOESNOTEXIST2';
 
-beforeAll(() => {
+const setMockApiResponses = (mockApiResponses: any) => {
   global.fetch = jest.fn((url: URL) => {
-    const mockApiResponses = [
-      {
-        url: 'https://v2.api.earningscall.biz/symbols-v2.txt?apikey=demo',
-        result: {
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(symbolsResponseText),
-          headers: new Headers({}),
-        },
-      },
-      {
-        url: 'https://v2.api.earningscall.biz/events?apikey=demo&exchange=NASDAQ&symbol=ABC',
-        result: {
-          ok: true,
-          status: 200,
-          json: () => eventsResponseJson,
-        },
-      },
-      {
-        url: 'https://v2.api.earningscall.biz/symbols-v2.txt?apikey=My+Custom+API+Key',
-        result: {
-          ok: true,
-          status: 200,
-          text: () => Promise.resolve(symbolsResponseText),
-          headers: new Headers({}),
-        },
-      },
-      {
-        url: 'https://v2.api.earningscall.biz/transcript?apikey=My+Custom+API+Key&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=1',
-        result: {
-          ok: true,
-          status: 200,
-          json: () => transcriptResponseJson,
-        },
-      },
-      {
-        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=1',
-        result: {
-          ok: true,
-          status: 200,
-          json: () => transcriptResponseJson,
-          headers: new Headers({}),
-        },
-      },
-      {
-        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=2',
-        result: {
-          ok: true,
-          status: 200,
-          json: () => transcriptLevel2ResponseJson,
-          headers: new Headers({}),
-        },
-      },
-      {
-        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=3',
-        result: {
-          ok: true,
-          status: 200,
-          json: () => transcriptLevel3ResponseJson,
-          headers: new Headers({}),
-        },
-      },
-      {
-        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=4',
-        result: {
-          ok: true,
-          status: 200,
-          json: () => level4Response,
-          headers: new Headers({}),
-        },
-      },
-      {
-        url: 'https://v2.api.earningscall.biz/symbols/sp500.txt?apikey=demo',
-        result: {
-          ok: true,
-          status: 200,
-          text: () => sp500CompaniesTxtFile,
-          headers: new Headers({}),
-        },
-      },
-      {
-        url: 'https://v2.api.earningscall.biz/symbols/sp500.txt?apikey=My+Custom+API+Key',
-        result: {
-          ok: true,
-          status: 200,
-          text: () => sp500CompaniesWithNonexistentSymbolsTxtFile,
-          headers: new Headers({}),
-        },
-      },
-      {
-        url: 'https://v2.api.earningscall.biz/transcript?apikey=CUSTOM_API_KEY&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=1',
-        result: {
-          ok: true,
-          status: 404,
-          headers: new Headers({}),
-        },
-      },
-      {
-        url: 'https://v2.api.earningscall.biz/transcript?apikey=BASIC_PLAN_API_KEY&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=4',
-        result: {
-          ok: false,
-          status: 403,
-          headers: new Headers({
-            'x-plan-name': 'basic',
-          }),
-        },
-      },
-      {
-        url: 'https://v2.api.earningscall.biz/symbols-v2.txt?apikey=INVALID_API_KEY',
-        result: {
-          ok: false,
-          status: 401,
-          headers: new Headers({}),
-        },
-      },
-      {
-        url: 'https://v2.api.earningscall.biz/audio?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1',
-        result: {
-          ok: true,
-          status: 200,
-          arrayBuffer: () => Promise.resolve(new Uint8Array([0, 0, 0, 0, 0])),
-          headers: new Headers({
-            'content-length': '100',
-            'content-type': 'audio/mpeg',
-            'last-modified': '2024-01-01T00:00:00.000Z',
-          }),
-        },
-      },
-    ];
     for (const mockApiResponse of mockApiResponses) {
       if (url.toString() === mockApiResponse.url) {
         return mockApiResponse.result;
@@ -304,7 +186,9 @@ beforeAll(() => {
     }
     return Promise.reject(new Error(`Unhandled request: ${url}`));
   }) as jest.Mock;
-});
+};
+
+beforeAll(() => {});
 
 afterAll(() => {
   jest.restoreAllMocks();
@@ -317,17 +201,29 @@ beforeEach(() => {
 
 describe('company', () => {
   test('getCompany non demo account throws InsufficientApiAccessError', async () => {
+    setMockApiResponses([demoSymbolsMock]);
     await expect(getCompany({ symbol: 'XYZ' })).rejects.toThrow(
       '"XYZ" requires an API Key for access. To get your API Key, see: https://earningscall.biz/api-pricing',
     );
   });
 
   test('getCompany with invalid api key throws NotFoundError', async () => {
+    setMockApiResponses([
+      {
+        url: 'https://v2.api.earningscall.biz/symbols-v2.txt?apikey=INVALID_API_KEY',
+        result: {
+          ok: false,
+          status: 401,
+          headers: new Headers({}),
+        },
+      },
+    ]);
     setApiKey('INVALID_API_KEY');
     await expect(getCompany({ symbol: 'ABC' })).rejects.toThrow('Unauthorized');
   });
 
   test('getCompany', async () => {
+    setMockApiResponses([demoSymbolsMock]);
     const company = await getCompany({ symbol: 'ABC' });
     expect(company.name).toBe('ABC Test Company Inc.');
     expect(company.companyInfo.exchange).toBe('NASDAQ');
@@ -346,6 +242,7 @@ describe('company', () => {
   });
 
   test('getCompany by symbol and exchange', async () => {
+    setMockApiResponses([demoSymbolsMock]);
     const company = await getCompany({ symbol: 'ABC', exchange: 'NASDAQ' });
     expect(company.name).toBe('ABC Test Company Inc.');
     expect(company.companyInfo.exchange).toBe('NASDAQ');
@@ -353,6 +250,17 @@ describe('company', () => {
   });
 
   test('get events', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/events?apikey=demo&exchange=NASDAQ&symbol=ABC',
+        result: {
+          ok: true,
+          status: 200,
+          json: () => eventsResponseJson,
+        },
+      },
+    ]);
     const company = await getCompany({ symbol: 'ABC' });
     const events = await company.events();
     expect(events.length).toEqual(8);
@@ -361,122 +269,489 @@ describe('company', () => {
     expect(events[0].conferenceDate).toEqual('2024-10-31T17:00:00.000-04:00');
   });
 
-  test('get transcript is missing', async () => {
+  test('get transcript wrong api key', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=WRONG_API_KEY&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=1',
+        result: {
+          ok: false,
+          status: 401,
+          headers: new Headers({}),
+        },
+      },
+    ]);
     const company = await getCompany({ symbol: 'ABC' });
-    setApiKey('CUSTOM_API_KEY');
-    const transcript = await company.getTranscript({ year: 2022, quarter: 1 });
+    setApiKey('WRONG_API_KEY');
+    await expect(company.getBasicTranscript({ year: 2022, quarter: 1 })).rejects.toThrow(
+      'Unauthorized',
+    );
+  });
+
+  test('get transcript is missing', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=1',
+        result: {
+          ok: true,
+          status: 404,
+          headers: new Headers({}),
+        },
+      },
+    ]);
+    const company = await getCompany({ symbol: 'ABC' });
+    const transcript = await company.getBasicTranscript({
+      year: 2022,
+      quarter: 1,
+    });
     expect(transcript).toBeUndefined();
   });
 
-  test('get enhanced transcript not authorized', async () => {
+  test('get speaker groups http 429 too many requests', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=2',
+        result: {
+          ok: false,
+          status: 429,
+          headers: new Headers({}),
+        },
+      },
+    ]);
+    const company = await getCompany({ symbol: 'ABC' });
+    await expect(company.getSpeakerGroups({ year: 2022, quarter: 1 })).rejects.toThrow(
+      'Too many requests',
+    );
+  });
+
+  test('get speaker groups not found', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=2',
+        result: {
+          ok: true,
+          status: 404,
+          headers: new Headers({}),
+        },
+      },
+    ]);
+    const company = await getCompany({ symbol: 'ABC' });
+    const transcript = await company.getSpeakerGroups({
+      year: 2022,
+      quarter: 1,
+    });
+    expect(transcript).toBeUndefined();
+  });
+
+  test('get speaker groups not authorized', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=2',
+        result: {
+          ok: false,
+          status: 403,
+          headers: new Headers({
+            'x-plan-name': 'basic',
+          }),
+        },
+      },
+    ]);
+    const company = await getCompany({ symbol: 'ABC' });
+    await expect(
+      company.getSpeakerGroups({ year: 2022, quarter: 1 }),
+    ).rejects.toThrow(
+      'Your plan (basic) does not include Enhanced Transcript Data. Upgrade your plan here: https://earningscall.biz/api-pricing',
+    );
+  });
+
+  test('get transcript by passing event', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=1',
+        result: {
+          ok: true,
+          status: 200,
+          json: () => transcriptResponseJson,
+        },
+      },
+    ]);
+    const company = await getCompany({ symbol: 'ABC' });
+    const transcript = await company.getBasicTranscript({
+      event: { year: 2022, quarter: 1, conferenceDate: '2022-01-01' },
+    });
+    expect(transcript?.event.year).toBe(2022);
+    expect(transcript?.event.quarter).toBe(1);
+    expect(transcript?.event.conferenceDate).toBe('2022-01-01');
+  });
+
+  test('get word level timestamps not found', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=3',
+        result: {
+          ok: true,
+          status: 404,
+          headers: new Headers({}),
+        },
+      },
+    ]);
+    const company = await getCompany({ symbol: 'ABC' });
+    const transcript = await company.getWordLevelTimestamps({
+      year: 2022,
+      quarter: 1,
+    });
+    expect(transcript).toBeUndefined();
+  });
+
+  test('get word level timestamps not authorized', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=3',
+        result: {
+          ok: false,
+          status: 403,
+          headers: new Headers({
+            'x-plan-name': 'basic',
+          }),
+        },
+      },
+    ]);
+    const company = await getCompany({ symbol: 'ABC' });
+    await expect(
+      company.getWordLevelTimestamps({ year: 2022, quarter: 1 }),
+    ).rejects.toThrow(
+      'Your plan (basic) does not include Enhanced Transcript Data. Upgrade your plan here: https://earningscall.biz/api-pricing',
+    );
+  });
+
+  test('get question and answer not authorized', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=BASIC_PLAN_API_KEY&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=4',
+        result: {
+          ok: false,
+          status: 403,
+          headers: new Headers({
+            'x-plan-name': 'basic',
+          }),
+        },
+      },
+    ]);
     const company = await getCompany({ symbol: 'ABC' });
     setApiKey('BASIC_PLAN_API_KEY');
     await expect(
-      company.getTranscript({
+      company.getQuestionAndAnswerTranscript({
         year: 2022,
         quarter: 1,
-        level: 4,
       }),
     ).rejects.toThrow(
       'Your plan (basic) does not include Enhanced Transcript Data. Upgrade your plan here: https://earningscall.biz/api-pricing',
     );
   });
 
-  test('get transcript', async () => {
+  test('get basic transcript validates parameters', async () => {
+    setMockApiResponses([demoSymbolsMock]);
     const company = await getCompany({ symbol: 'ABC' });
+    const options = {
+      year: undefined,
+      quarter: undefined,
+    } as unknown as GetTranscriptOptions;
 
-    await expect(company.getTranscript({})).rejects.toThrow(
+    await expect(company.getBasicTranscript(options)).rejects.toThrow(
       'Must specify either event or year and quarter',
     );
 
     await expect(
-      company.getTranscript({ year: 2022, quarter: 0 }),
+      company.getBasicTranscript({ year: 2022, quarter: 0 }),
     ).rejects.toThrow('Invalid quarter. Must be one of: {1,2,3,4}');
 
     await expect(
-      company.getTranscript({ year: 2022, quarter: 1, level: 5 }),
-    ).rejects.toThrow('Invalid level. Must be one of: {1,2,3,4}');
-
-    await expect(
-      company.getTranscript({ year: 2022, quarter: 1, level: 0 }),
-    ).rejects.toThrow('Invalid level. Must be one of: {1,2,3,4}');
-
-    await expect(
-      company.getTranscript({ year: 1989, quarter: 1, level: 1 }),
+      company.getBasicTranscript({ year: 1989, quarter: 1 }),
     ).rejects.toThrow('Invalid year. Must be between 1990 and 2030');
 
     await expect(
-      company.getTranscript({ year: 2031, quarter: 1, level: 1 }),
+      company.getBasicTranscript({ year: 2031, quarter: 1 }),
+    ).rejects.toThrow('Invalid year. Must be between 1990 and 2030');
+  });
+
+  test('get basic transcript success', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=1',
+        result: {
+          ok: true,
+          status: 200,
+          json: () => transcriptResponseJson,
+        },
+      },
+    ]);
+    const company = await getCompany({ symbol: 'ABC' });
+    const options = {
+      year: undefined,
+      quarter: undefined,
+    } as unknown as GetTranscriptOptions;
+
+    await expect(company.getBasicTranscript(options)).rejects.toThrow(
+      'Must specify either event or year and quarter',
+    );
+
+    await expect(
+      company.getBasicTranscript({ year: 2022, quarter: 0 }),
+    ).rejects.toThrow('Invalid quarter. Must be one of: {1,2,3,4}');
+
+    await expect(
+      company.getBasicTranscript({ year: 1989, quarter: 1 }),
     ).rejects.toThrow('Invalid year. Must be between 1990 and 2030');
 
-    const transcript = await company.getTranscript({ year: 2022, quarter: 1 });
+    await expect(
+      company.getBasicTranscript({ year: 2031, quarter: 1 }),
+    ).rejects.toThrow('Invalid year. Must be between 1990 and 2030');
 
-    expect(transcript?.event?.year).toBe(2022);
-    expect(transcript?.event?.quarter).toBe(1);
-    expect(transcript?.event?.conferenceDate).toBe('2022-01-01');
+    const transcript = await company.getBasicTranscript({
+      year: 2022,
+      quarter: 1,
+    });
+
+    expect(transcript?.event.year).toBe(2022);
+    expect(transcript?.event.quarter).toBe(1);
+    expect(transcript?.event.conferenceDate).toBe('2022-01-01');
     expect(transcript?.text).toBe(
       'Good day and welcome to the ABC Test Company Inc. Q1 FY 2022 earnings conference call.',
     );
   });
 
-  test('get transcript with api key', async () => {
+  test('get transcript with custom api key', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/symbols-v2.txt?apikey=My+Custom+API+Key',
+        result: {
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(symbolsResponseText),
+          headers: new Headers({}),
+        },
+      },
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=My+Custom+API+Key&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=1',
+        result: {
+          ok: true,
+          status: 200,
+          json: () => transcriptResponseJson,
+        },
+      },
+    ]);
     setApiKey('My Custom API Key');
     const company = await getCompany({ symbol: 'ABC' });
-    const transcript = await company.getTranscript({ year: 2022, quarter: 1 });
+    const transcript = await company.getBasicTranscript({
+      year: 2022,
+      quarter: 1,
+    });
     expect(transcript?.event.year).toBe(2022);
     expect(transcript?.event.quarter).toBe(1);
+    expect(transcript?.event.conferenceDate).toBe('2022-01-01');
   });
 
   test('get transcript level 2', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=2',
+        result: {
+          ok: true,
+          status: 200,
+          json: () => transcriptLevel2ResponseJson,
+        },
+      },
+    ]);
     const company = await getCompany({ symbol: 'ABC' });
 
-    const transcript = await company.getTranscript({
+    const transcript = await company.getSpeakerGroups({
       year: 2022,
       quarter: 1,
-      level: 2,
     });
 
-    expect(transcript?.event?.year).toBe(2022);
-    expect(transcript?.event?.quarter).toBe(1);
-    expect(transcript?.event?.conferenceDate).toBe('2022-01-01');
-    expect(transcript?.text).toBe(
-      "Good day and welcome to the ABC Test Company Inc. Q1 FY 2022 earnings conference call. Today's call is being recorded. Please go ahead. Thank you. Good afternoon, and thank you for joining us. I am the awesome CEO John Smith.",
+    expect(transcript?.event.year).toBe(2022);
+    expect(transcript?.event.quarter).toBe(1);
+    expect(transcript?.event.conferenceDate).toBe('2022-01-01');
+    expect(transcript?.speakers[0].speakerInfo?.name).toBe('Operator');
+    expect(transcript?.speakers[0].speakerInfo?.title).toBe('Host');
+    expect(transcript?.speakers[0].text).toBe(
+      "Good day and welcome to the ABC Test Company Inc. Q1 FY 2022 earnings conference call. Today's call is being recorded. Please go ahead.",
     );
-    expect(transcript?.speakers?.[0]?.speakerInfo?.name).toBe('Operator');
-    expect(transcript?.speakers?.[0]?.speakerInfo?.title).toBe('Host');
-    expect(transcript?.speakers?.[1]?.speakerInfo?.name).toBe('John Smith');
-    expect(transcript?.speakers?.[1]?.speakerInfo?.title).toBe('CEO');
+    expect(transcript?.speakers[1].speakerInfo?.name).toBe('John Smith');
+    expect(transcript?.speakers[1].speakerInfo?.title).toBe('CEO');
+    expect(transcript?.speakers[1].text).toBe(
+      'Thank you. Good afternoon, and thank you for joining us. I am the awesome CEO John Smith.',
+    );
+  });
+
+  test('get transcript level 2 not found', async () => {
+    const company = await getCompany({ symbol: 'ABC' });
+
+    const transcript = await company.getSpeakerGroups({
+      year: 2022,
+      quarter: 1,
+    });
+
+    expect(transcript?.event.year).toBe(2022);
+    expect(transcript?.event.quarter).toBe(1);
+    expect(transcript?.event.conferenceDate).toBe('2022-01-01');
+    expect(transcript?.speakers[0].speakerInfo?.name).toBe('Operator');
+    expect(transcript?.speakers[0].speakerInfo?.title).toBe('Host');
+    expect(transcript?.speakers[1].speakerInfo?.name).toBe('John Smith');
+    expect(transcript?.speakers[1].speakerInfo?.title).toBe('CEO');
+  });
+
+
+  test('get transcript level 3 http 429 too many requests', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=3',
+        result: {
+          ok: false,
+          status: 429,
+          headers: new Headers({}),
+        },
+      },
+    ]);
+    const company = await getCompany({ symbol: 'ABC' });
+    await expect(
+      company.getWordLevelTimestamps({ year: 2022, quarter: 1 }),
+    ).rejects.toThrow('Too many requests');
   });
 
   test('get transcript level 3', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=3',
+        result: {
+          ok: true,
+          status: 200,
+          json: () => transcriptLevel3ResponseJson,
+        },
+      },
+    ]);
     const company = await getCompany({ symbol: 'ABC' });
 
-    const transcript = await company.getTranscript({
+    const transcript = await company.getWordLevelTimestamps({
       year: 2022,
       quarter: 1,
-      level: 3,
     });
 
-    expect(transcript?.event?.year).toBe(2022);
-    expect(transcript?.event?.quarter).toBe(1);
-    expect(transcript?.event?.conferenceDate).toBe('2022-01-01');
-    expect(transcript?.text).toBe(
-      'Good day and welcome to the ABC Test Company Inc. Q1 FY 2022 earnings conference call. Thank you Good afternoon and thank you for joining us I am the awesome CEO John Smith.',
-    );
+    expect(transcript?.event.year).toBe(2022);
+    expect(transcript?.event.quarter).toBe(1);
+    expect(transcript?.event.conferenceDate).toBe('2022-01-01');
+    expect(transcript?.speakers[0].words).toEqual([
+      'Good',
+      'day',
+      'and',
+      'welcome',
+      'to',
+      'the',
+      'ABC',
+      'Test',
+      'Company',
+      'Inc.',
+      'Q1',
+      'FY',
+      '2022',
+      'earnings',
+      'conference',
+      'call.',
+    ]);
+    expect(transcript?.speakers[1].words).toEqual([
+      'Thank',
+      'you',
+      'Good',
+      'afternoon',
+      'and',
+      'thank',
+      'you',
+      'for',
+      'joining',
+      'us',
+      'I',
+      'am',
+      'the',
+      'awesome',
+      'CEO',
+      'John',
+      'Smith.',
+    ]);
   });
 
-  test('get transcript level 4', async () => {
+  test('get question and answer not found', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=4',
+        result: {
+          ok: true,
+          status: 404,
+          headers: new Headers({}),
+        },
+      },
+    ]);
     const company = await getCompany({ symbol: 'ABC' });
-
-    const transcript = await company.getTranscript({
+    const transcript = await company.getQuestionAndAnswerTranscript({
       year: 2022,
       quarter: 1,
-      level: 4,
+    });
+    expect(transcript).toBeUndefined();
+  });
+
+  test('get question and answer http 429 too many requests', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=4',
+        result: {
+          ok: false,
+          status: 429,
+          headers: new Headers({}),
+        },
+      },
+    ]);
+    const company = await getCompany({ symbol: 'ABC' });
+    await expect(
+      company.getQuestionAndAnswerTranscript({ year: 2022, quarter: 1 }),
+    ).rejects.toThrow('Too many requests');
+  });
+
+  test('get question and answer level 4', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/transcript?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1&level=4',
+        result: {
+          ok: true,
+          status: 200,
+          json: () => level4Response,
+        },
+      },
+    ]);
+    const company = await getCompany({ symbol: 'ABC' });
+
+    const transcript = await company.getQuestionAndAnswerTranscript({
+      year: 2022,
+      quarter: 1,
     });
 
-    expect(transcript?.event?.year).toBe(2022);
-    expect(transcript?.event?.quarter).toBe(1);
-    expect(transcript?.event?.conferenceDate).toBe('2022-01-01');
+    expect(transcript?.event.year).toBe(2022);
+    expect(transcript?.event.quarter).toBe(1);
+    expect(transcript?.event.conferenceDate).toBe('2022-01-01');
     expect(transcript?.preparedRemarks).toBe(
       "Good day and welcome to the Apple Q1 FY 2022 earnings conference call. Today's call is being recorded. At this time, for opening remarks and introductions, I would like to turn the call over to Tejas Ghala, Director of Investor Relations and Corporate Finance. Please go ahead. Thank you. Good afternoon, and thank you for joining us. Speaking first today is Apple CEO Tim Cook, and he'll be followed by CFO Luca Maestri. After that, we'll open the call to questions from analysts.",
     );
@@ -486,6 +761,7 @@ describe('company', () => {
   });
 
   test('getAllCompanies', async () => {
+    setMockApiResponses([demoSymbolsMock]);
     const companies = await getAllCompanies();
     expect(companies.length).toBe(2);
     const names = companies.map((company) => company.companyInfo.name);
@@ -494,12 +770,34 @@ describe('company', () => {
   });
 
   test('getSP500Companies', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/symbols/sp500.txt?apikey=demo',
+        result: {
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(sp500CompaniesTxtFile),
+        },
+      },
+    ]);
     const companies = await getSP500Companies();
     expect(companies.length).toBe(2);
   });
 
   test('getSP500Companies with nonexistent symbols', async () => {
-    setApiKey('My Custom API Key');
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/symbols/sp500.txt?apikey=demo',
+        result: {
+          ok: true,
+          status: 200,
+          text: () =>
+            Promise.resolve(sp500CompaniesWithNonexistentSymbolsTxtFile),
+        },
+      },
+    ]);
     const companies = await getSP500Companies();
     expect(companies.length).toBe(2);
   });
@@ -518,36 +816,103 @@ describe('company', () => {
     expect(convertedData.symbol).toBeUndefined();
   });
 
+  test('getAudioFile http 404 not found', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/audio?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1',
+        result: {
+          ok: false,
+          status: 404,
+          headers: new Headers({}),
+        },
+      },
+    ]);
+    const company = await getCompany({ symbol: 'ABC' });
+    const result = await company.downloadAudioFile({ year: 2022, quarter: 1 });
+    expect(result).toBeUndefined();
+  });
+
+  test('getAudioFile http 429 too many requests', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/audio?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1',
+        result: {
+          ok: false,
+          status: 429,
+          headers: new Headers({}),
+        },
+      },
+    ]);
+    const company = await getCompany({ symbol: 'ABC' });
+    await expect(
+      company.downloadAudioFile({ year: 2022, quarter: 1 }),
+    ).rejects.toThrow('Too many requests');
+  });
+
   test('getAudioFile with outputFilePath specified', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/audio?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1',
+        result: {
+          ok: true,
+          status: 200,
+          arrayBuffer: () => Promise.resolve(new Uint8Array([0, 0, 0, 0, 0])),
+          headers: new Headers({
+            'content-length': '100',
+            'content-type': 'audio/mpeg',
+            'last-modified': '2024-01-01T00:00:00.000Z',
+          }),
+        },
+      },
+    ]);
     const tempFilePath = path.join(
       os.tmpdir(),
       `ABC_2022_q1-${Date.now()}.mp3`,
     );
     const company = await getCompany({ symbol: 'ABC' });
-    const audioFile = await company.getAudioFile({
+    const audioFile = await company.downloadAudioFile({
       year: 2022,
       quarter: 1,
       outputFilePath: tempFilePath,
     });
-    expect(audioFile.contentLength).toBe(100);
-    expect(audioFile.contentType).toBe('audio/mpeg');
-    expect(audioFile.lastModified).toBeDefined();
-    expect(audioFile.outputFilePath).toBe(tempFilePath);
+    expect(audioFile?.contentLength).toBe(100);
+    expect(audioFile?.contentType).toBe('audio/mpeg');
+    expect(audioFile?.lastModified).toBeDefined();
+    expect(audioFile?.outputFilePath).toBe(tempFilePath);
     expect(fs.existsSync(tempFilePath)).toBe(true);
     fs.unlinkSync(tempFilePath);
   });
 
   test('getAudioFile without outputFilePath specified', async () => {
+    setMockApiResponses([
+      demoSymbolsMock,
+      {
+        url: 'https://v2.api.earningscall.biz/audio?apikey=demo&exchange=NASDAQ&symbol=ABC&year=2022&quarter=1',
+        result: {
+          ok: true,
+          status: 200,
+          arrayBuffer: () => Promise.resolve(new Uint8Array([0, 0, 0, 0, 0])),
+          headers: new Headers({
+            'content-length': '100',
+            'content-type': 'audio/mpeg',
+            'last-modified': '2024-01-01T00:00:00.000Z',
+          }),
+        },
+      },
+    ]);
     const company = await getCompany({ symbol: 'ABC' });
-    const audioFile = await company.getAudioFile({
+    const audioFile = await company.downloadAudioFile({
       year: 2022,
       quarter: 1,
     });
-    expect(audioFile.contentLength).toBe(100);
-    expect(audioFile.contentType).toBe('audio/mpeg');
-    expect(audioFile.lastModified).toBeDefined();
-    expect(audioFile.outputFilePath).toBeDefined();
-    expect(fs.existsSync(audioFile.outputFilePath!)).toBe(true);
-    fs.unlinkSync(audioFile.outputFilePath!);
+    expect(audioFile?.contentLength).toBe(100);
+    expect(audioFile?.contentType).toBe('audio/mpeg');
+    expect(audioFile?.lastModified).toBeDefined();
+    expect(audioFile?.outputFilePath).toBeDefined();
+    expect(fs.existsSync(audioFile?.outputFilePath!)).toBe(true);
+    fs.unlinkSync(audioFile?.outputFilePath!);
   });
 });

--- a/src/types/company.ts
+++ b/src/types/company.ts
@@ -1,3 +1,5 @@
+import { EarningsEvent } from './event';
+
 /**
  * Represents information about a company including its exchange listing,
  * symbol, name, and classification details.
@@ -19,15 +21,24 @@ export interface GetCompanyOptions {
   exchange?: string;
 }
 
-export interface GetAudioFileOptions {
+export interface DownloadAudioFileOptions {
   year: number;
   quarter: number;
   outputFilePath?: string;
 }
 
-export interface GetAudioFileResponse {
+export interface DownloadAudioFileResponse {
   outputFilePath?: string;
   contentLength?: number;
   contentType?: string;
   lastModified?: Date;
+}
+
+export interface GetTranscriptOptions {
+  year: number;
+  quarter: number;
+}
+
+export interface GetTranscriptFromEventOptions {
+  event: EarningsEvent;
 }

--- a/src/types/transcript.ts
+++ b/src/types/transcript.ts
@@ -8,16 +8,46 @@ export type SpeakerInfo = {
 export type Speaker = {
   speaker: string;
   speakerInfo?: SpeakerInfo;
-  text?: string;
-  words?: string[];
-  startTimes?: number[];
+  text: string;
 };
 
-export type Transcript = {
+export type WordLevelSpeaker = {
+  speaker: string;
+  speakerInfo?: SpeakerInfo;
+  words: string[];
+  startTimes: number[];
+};
+
+/**
+ * A transcript of a single earnings call.
+ */
+export type WordLevelTimestampsTranscript = {
+  event: EarningsEvent;
+  speakers: WordLevelSpeaker[];
+};
+
+/**
+ * A transcript of a single earnings call.
+ */
+export type QuestionAndAnswersTranscript = {
+  event: EarningsEvent;
+  preparedRemarks: string;
+  questionsAndAnswers: string;
+};
+
+/**
+ * A basic transcript of a single earnings call.
+ */
+export type BasicTranscript = {
   event: EarningsEvent;
   text: string;
-  speakers?: Speaker[];
-  preparedRemarks?: string;
-  questionsAndAnswers?: string;
+};
+
+/**
+ * A transcript of a single earnings call with speaker groups.
+ */
+export type SpeakerGroups = {
+  event: EarningsEvent;
+  speakers: Speaker[];
   speakerNameMapV2?: { [key: string]: SpeakerInfo };
 };


### PR DESCRIPTION
1. Eliminate the `getTranscript()` function from `Company` class.  It will be replaced with 4 new functions: `getBasicTranscript()`, `getSpeakerGroups()`, `getWordLevelTimestamps()`, and `getQuestionAndAnswerTranscript()`.
2. Eliminate the `Transcript` type, which is now replaced with 4 separate return types, each different according to the function.